### PR TITLE
Remove GetFullPath on relative path directory

### DIFF
--- a/uSync.Publisher.Static/Service/uSyncStaticSiteService.cs
+++ b/uSync.Publisher.Static/Service/uSyncStaticSiteService.cs
@@ -57,7 +57,7 @@ namespace uSync.Publisher.Static
             this.contextFactory = contextFactory;
 
             this.syncRoot = Path.GetFullPath(Path.Combine(settings.LocalTempPath, "uSync", "pack"));
-            this.configFile = Path.GetFullPath(Path.Combine(Umbraco.Core.IO.SystemDirectories.Config + "/uSync.Publish.config"));
+            this.configFile = Path.Combine(Umbraco.Core.IO.SystemDirectories.Config + "/uSync.Publish.config");
 
             this.deployers = deployers;
 


### PR DESCRIPTION
The SystemDirectories.Config folder is a site-relative folder, specified with a tilde.  Trying to GetFullPath on it causes it to return the current working directory, appended with "~\config\uSync.Publish.config".  Instead it should just get the combined path and then resolve the full path later upon use.